### PR TITLE
Fix - wrong userid in admin.php?view=user&id={id}

### DIFF
--- a/src/userinfo/hooks/user_settings_post.php
+++ b/src/userinfo/hooks/user_settings_post.php
@@ -1,6 +1,10 @@
 <?php if(count(get_included_files()) ==1) die(); //Direct Access Not Permitted
 global $user,$userId,$usFormUpdate,$form_valid;
-$usFormUpdate = $user->data()->id;
+if(currentPage() == "user_settings.php"){
+  $usFormUpdate = $user->data()->id;
+}else{
+  $usFormUpdate = $userId;
+}
 
 $check = $db->query("SELECT id FROM users_form")->count();
 if($check > 0){


### PR DESCRIPTION
in admin.php?view=user&id={id} 
usFormUpdate = $user->data()->id; is used for user id. Wrong user is updated! 

fixed with same if-statement from singleuser_bottom.php