### PR TITLE
Update of displayBadges(): include badge name tooltip

### DIFF
--- a/src/badges/functions.php
+++ b/src/badges/functions.php
@@ -8,9 +8,12 @@ if(!function_exists('displayBadges')){
     $c = $q->count();
     if($c > 0){
       $badges = $q->results();
+      $badgeids = implode("', '", array_column($badges, 'badge_id'));
+      $q_badges = $db->query("SELECT * FROM plg_badges WHERE id = ('".$badgeids."')");
+      $badges = $q_badges->results();
       foreach($badges as $b){
-        if(file_exists($abs_us_root.$us_url_root."usersc/plugins/badges/files/".$b->badge_id.".png")){ ?>
-          <img src="<?=$us_url_root."usersc/plugins/badges/files/".$b->badge_id.".png"?>" alt="" height="<?=$size?>">
+        if(file_exists($abs_us_root.$us_url_root."usersc/plugins/badges/files/".$b->id.".png")){ ?>
+          <img src="<?=$us_url_root."usersc/plugins/badges/files/".$b->id.".png"?>" title="<?=$b->badge?>" alt="<?=$b->badge?>" height="<?=$size?>">
         <?php }
       }
     }


### PR DESCRIPTION
This code is able to display a tooltip on hover (and an alt text for accessibility) on the badge image when called, for example on the account page. This makes the wondering user aware of how the badge they have achieved is called. Since badge names are already stored in the database, and the display of the image doesn't change, this change is not that intrusive :)