### PR TITLE
Allow Webhook to return custom object/msg

### DIFF
--- a/src/webhooks/assets/testscript.php
+++ b/src/webhooks/assets/testscript.php
@@ -18,3 +18,6 @@ dump($json);
 
 $db->insert("logs",["logtype"=>"script test","lognote"=>"Did it work?"]);
 dnd($data);
+
+//If you set $return_object as an object or string then this will be returned
+//instead of {msg:"success"}

--- a/src/webhooks/webhook.php
+++ b/src/webhooks/webhook.php
@@ -142,7 +142,12 @@ if($webhook->disabled > 0){
 }
 
 $action = performWebhookAction($webhook->id,$webhook->action_type,$webhook->action,$data);
-$msg['msg'] = $action;
+if (is_string($action)) {
+  $msg['msg'] = $action;
+} else {
+  $msg=$action;
+  $action=json_encode($msg);
+}
 $fields = [
   'hook'=>$webhook->id,
   'ip'=>$ip,
@@ -175,7 +180,8 @@ function performWebhookAction($id,$action_type,$action,$data){
   }elseif($action_type == "php"){
     if(file_exists($abs_us_root.$us_url_root."usersc/plugins/webhooks/assets/".$action)){
       require_once($abs_us_root.$us_url_root."usersc/plugins/webhooks/assets/".$action);
-      return "success";
+      if(empty($return_object)) return "success";
+      else return $return_object;
     }else{
       return "File not found";
     }


### PR DESCRIPTION
Changed webhook to allow for a custom object or string to be returned from the called script defaulting to msg:success